### PR TITLE
fix(auth): prevent infinite refresh loop in AuthContext

### DIFF
--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -172,12 +172,7 @@ export default function ProfilePage() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <NavBar
-        user={{
-          name: userName,
-          avatarUrl: photo || "/img/defaultProfileImage.png",
-        }}
-      />
+      <NavBar />
       <section className="flex-1 bg-white flex flex-col items-center justify-center py-20">
         <h2 className="text-3xl font-bold text-center text-black mb-12">
           Profile

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -25,7 +25,7 @@ import { supabase } from "@/lib/supabaseClient";
 
 const NavBar: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const { user, loading, fetchUser, authStateChanged } = useAuth(); 
+  const { user, loading, fetchUser } = useAuth();
 
   const menuItems = [
     { icon: User, label: "Profile", href: "/profile" },
@@ -45,25 +45,6 @@ const NavBar: React.FC = () => {
 
   const displayName = user?.full_name || "User";
   const avatarUrl = user?.profile_picture || "/img/defaultProfileImage.png";
-
-  useEffect(() => {
-    const { data: listener } = supabase.auth.onAuthStateChange(
-      async (event, session) => {
-        if (event === "SIGNED_IN") {
-          await fetchUser(); 
-        }
-      }
-    );
-    return () => {
-      listener.subscription.unsubscribe();
-    };
-  }, []);
-
-  useEffect(() => {
-    if (authStateChanged) {
-      fetchUser(); // Ensure user data is refreshed when auth state changes
-    }
-  }, [authStateChanged, fetchUser]); 
 
   return (
     <nav className="bg-white fixed w-full h-[88px] z-20 top-0 start-0 border-b border-gray-200 shadow-sm">


### PR DESCRIPTION
This update improves how we handle user authentication and makes the code easier to maintain. Here's what was fixed:

**1)Removed duplicate auth listener from NavBar**
We already listen for auth changes in AuthProvider, so the extra one in NavBar was causing unnecessary re-fetches and could lead to bugs.

**2)Got rid of authStateChanged logic**
It was no longer needed because Supabase already triggers updates when auth changes. Keeping it just added complexity and extra renders.

**3)Cleared user before re-fetching**
Prevents old user data from showing up when someone logs out and logs in quickly.

**4)Cleaned up context types and usage**
Removed unused fields for a simpler and more reliable useAuth() experience.

This makes our auth system cleaner, avoids double-fetch issues, and ensures user info stays in sync across the app krub.