### PR TITLE
feat(admin): enforce 5MB limit on cover image upload with preview

### DIFF
--- a/src/app/api/admin/courses-create/route.ts
+++ b/src/app/api/admin/courses-create/route.ts
@@ -1,5 +1,7 @@
-import {supabase} from '@/lib/supabaseClient';
-import { NextRequest } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabaseClient';
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
     try {
@@ -20,7 +22,7 @@ export async function POST(req: NextRequest) {
         } = body;
 
         if (!name) {
-            return Response.json({ error: 'Course name is required' }, { status: 400 });
+            return NextResponse.json({ error: 'Course name is required' }, { status: 400 });
         }
 
         const { data, error } = await supabase
@@ -42,15 +44,15 @@ export async function POST(req: NextRequest) {
             .select();
 
         if (error) {
-            return Response.json({ error: error.message }, { status: 500 });
+            return NextResponse.json({ error: error.message }, { status: 500 });
         }
 
-        return Response.json({ 
+        return NextResponse.json({ 
             message: 'Course added successfully', 
             data 
         }, { status: 201 });
     } catch (err) {
-        return Response.json({ 
+        return NextResponse.json({ 
             error: (err as Error).message || 'Internal Server Error' 
         }, { status: 500 });
     }

--- a/src/app/api/admin/courses-delete/[id]/route.ts
+++ b/src/app/api/admin/courses-delete/[id]/route.ts
@@ -1,38 +1,42 @@
-import {supabase} from '@/lib/supabaseClient';
-import { NextRequest } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { NextRequest, NextResponse } from 'next/server';
+export const runtime = 'nodejs';
 
-export async function DELETE(
-    req: NextRequest,
-     { params }: { params: { id: string } }
-) {
-    try {
-        const { id } = await params;
+const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
 
-        const { data: existingCourse, error: fetchError } = await supabase
-            .from('courses')
-            .select('id')
-            .eq('id', id)
-            .single();
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const { id } = await params;
 
-        if (fetchError || !existingCourse) {
-            return Response.json({ error: 'Course not found' }, { status: 404 });
-        }
+   
+    const { data: existingCourse, error: fetchError } = await supabaseAdmin
+      .from('courses')
+      .select('id')
+      .eq('id', id)
+      .single();
 
-        const { error } = await supabase
-            .from('courses')
-            .delete()
-            .eq('id', id);
-
-        if (error) {
-            return Response.json({ error: error.message }, { status: 500 });
-        }
-
-        return Response.json({ 
-            message: 'Course deleted successfully' 
-        }, { status: 200 });
-    } catch (err) {
-        return Response.json({ 
-            error: (err as Error).message || 'Internal Server Error' 
-        }, { status: 500 });
+    if (fetchError || !existingCourse) {
+      return NextResponse.json({ error: 'Course not found' }, { status: 404 });
     }
+
+    // Delete course
+    const { error } = await supabaseAdmin
+      .from('courses')
+      .delete()
+      .eq('id', id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ message: 'Course deleted successfully' }, { status: 200 });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message || 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/admin/upload-cover/route.ts
+++ b/src/app/api/admin/upload-cover/route.ts
@@ -1,0 +1,59 @@
+import { createClient } from '@supabase/supabase-js'
+import { NextRequest, NextResponse } from 'next/server'
+export const runtime = 'nodejs';
+
+// TODO: When uploading a new file for the same post, delete the old file first.
+const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+console.log('[upload-cover] route handler start');
+export async function POST(req: NextRequest) {
+  console.log('[upload-cover] request method:', req.method);
+  try {
+    const formData = await req.formData();
+    console.log('[upload-cover] formData entries:', Array.from(formData.entries()));
+    const file = formData.get('coverImage');
+    console.log('[upload-cover] file object:', file);
+
+    if (!file) {
+      console.error('[upload-cover] No file found');
+      return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+    }
+
+    if (file instanceof File && file.size > 5 * 1024 * 1024) {
+      console.error('[upload-cover] File too large:', file.size);
+      return NextResponse.json({ error: 'Cover image must be less than 5MB' }, { status: 400 });
+    }
+
+    const ext = (file instanceof File ? file.name : 'file').split('.').pop() || ''
+    const fileName = `course-cover-${Date.now()}.${ext}`
+
+    const arrayBuffer = await (file as File).arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const { data, error } = await supabaseAdmin
+      .storage
+      .from('courses-cover-image')
+      .upload(fileName, buffer, {
+        contentType: (file as File).type,
+        upsert: false
+      })
+
+    if (error) {
+      console.error('Supabase storage.upload error:', error);
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    const {
+      data: { publicUrl }
+    } = supabaseAdmin
+      .storage
+      .from('courses-cover-image')
+      .getPublicUrl(fileName)
+    return NextResponse.json({ url: publicUrl }, { status: 200 })
+  } catch (err) {
+    console.error('[upload-cover] caught exception:', err);
+    return NextResponse.json({ error: (err as Error).message || 'Internal Server Error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the course management system, including support for cover image uploads, improved form validation, and better error handling in API routes. The changes also introduce a new API endpoint for uploading course cover images. Below is a summary of the most important changes:

### Frontend Enhancements
* Added support for uploading and previewing course cover images in the `CreateCourse` component, including file validation for size and type. [[1]](diffhunk://#diff-ac9b82b737b43291b044f5707e49feccb25554ae749edce565950959e46df152L4-R4) [[2]](diffhunk://#diff-ac9b82b737b43291b044f5707e49feccb25554ae749edce565950959e46df152R30-R47) [[3]](diffhunk://#diff-ac9b82b737b43291b044f5707e49feccb25554ae749edce565950959e46df152L260-R318)
* Updated form validation to differentiate between draft and published courses, requiring only the course name for drafts. [[1]](diffhunk://#diff-ac9b82b737b43291b044f5707e49feccb25554ae749edce565950959e46df152R82-R91) [[2]](diffhunk://#diff-ac9b82b737b43291b044f5707e49feccb25554ae749edce565950959e46df152L101-R150)
* Adjusted success messages to reflect whether a course is saved as a draft or published.

### Backend Enhancements
* Introduced a new API route `src/app/api/admin/upload-cover/route.ts` to handle course cover image uploads using Supabase storage. This includes file size validation and public URL generation.
* Updated the `DELETE` route in `src/app/api/admin/courses-delete/[id]/route.ts` to use a dedicated Supabase client with service role credentials for administrative operations. ([src/app/api/admin/courses-delete/[id]/route.tsL1-R40](diffhunk://#diff-693cd59b3ae08ab0e0e3e4191172ff49f5d17284961da60d19be36640a1e75deL1-R40))

### Error Handling Improvements
* Replaced `Response.json` with `NextResponse.json` in the `POST` route of `src/app/api/admin/courses-create/route.ts` for consistency with Next.js conventions. [[1]](diffhunk://#diff-a8406ae0303413430984603c82eca6616248e4a54141bdcefef8b3e9771bbbdbL23-R25) [[2]](diffhunk://#diff-a8406ae0303413430984603c82eca6616248e4a54141bdcefef8b3e9771bbbdbL45-R55)