### PR TITLE
User/course detail page

### DIFF
--- a/src/app/(main)/course-detail/[courseId]/page.tsx
+++ b/src/app/(main)/course-detail/[courseId]/page.tsx
@@ -63,7 +63,7 @@ const CourseDetailPage: React.FC = () => {
 
         const { data: otherCourseData } = await supabase
           .from("courses")
-          .select("id, name, summary, price, lessons!inner(id, sub_lessons(count))")
+          .select("id, name, summary, price, cover_image_url, lessons!inner(id, sub_lessons(count))")
           .neq("id", courseId);
 
         if (otherCourseData) {
@@ -148,7 +148,7 @@ const CourseDetailPage: React.FC = () => {
 
             <div className="my-12">
               <h2 className="text-2xl font-bold mb-4">Course Detail</h2>
-              <div className="prose max-w-none text-gray-600">
+              <div className="prose max-w-none text-gray-600 break-words">
                 {courses?.detail?.split("\n\n").map((para: string, idx: number) => (
                   <p key={idx} className="mb-4 whitespace-pre-line">{para}</p>
                 ))}
@@ -219,7 +219,15 @@ const CourseDetailPage: React.FC = () => {
             <div className="sticky top-30 p-6 border rounded-lg bg-white z-10">
               <span className="text-orange-500">Course</span>
               <h1 className="text-2xl font-bold mb-2">{courses?.name}</h1>
-              <p className="text-gray-600 mb-4">{courses?.summary}</p>
+              <p 
+                className="text-gray-600 mb-4 overflow-hidden text-ellipsis break-words"
+                style={{
+                  display: "-webkit-box",
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: "vertical",
+                }}    
+              >
+                {courses?.summary}</p>
               <p className="text-2xl font-bold mb-6">
                 THB {courses?.price?.toLocaleString()}
               </p>

--- a/src/app/(main)/course-detail/[courseId]/page.tsx
+++ b/src/app/(main)/course-detail/[courseId]/page.tsx
@@ -64,7 +64,8 @@ const CourseDetailPage: React.FC = () => {
         const { data: otherCourseData } = await supabase
           .from("courses")
           .select("id, name, summary, price, cover_image_url, lessons!inner(id, sub_lessons(count))")
-          .neq("id", courseId);
+          .neq("id", courseId)
+          .eq("status", "published");
 
         if (otherCourseData) {
           const formatted = otherCourseData.map((course: any) => {

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -36,18 +36,31 @@ const CourseCard: React.FC<CourseCardProps> = ({ course }) => {
       }}
     >
       <div className="w-full h-[180px] rounded-t-xl overflow-hidden">
+        {course.cover_image_url ? (
         <img
           src={course.cover_image_url}
           alt={course.name}
           className="w-full h-full object-cover"
         />
+      ) : (
+        <div className="w-full h-full bg-gray-100 flex items-center justify-center text-gray-400 text-sm">
+          No Image
+        </div>
+      )}
       </div>
       <div className="p-4 flex flex-col gap-2 flex-1">
         <span className="text-[14px] text-orange-500 font-semibold">
           Course
         </span>
         <h3 className="font-semibold text-lg">{course.name}</h3>
-        <p className="text-gray-500 text-[15px] line-clamp-2">
+        <p 
+          className="text-gray-500 text-[15px] overflow-hidden text-ellipsis break-words"
+          style={{
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+          }}      
+        >
           {course.summary}
         </p>
       </div>


### PR DESCRIPTION
This PR improves the UI resilience and accessibility of the Course Detail and Course Card components by addressing long text overflow and broken image issues.

##Changes Included
- Clamped course summaries to 2 lines using -webkit-line-clamp and CSS fallback (no plugin required)
- Applied overflow handling (overflow-hidden, text-ellipsis, break-words) to prevent text from breaking layout on desktop and mobile
- Fixed broken image issue in CourseCard by:
- Conditionally rendering <img> only when cover_image_url is defined
- Updating the Supabase select(...) query to include cover_image_url in otherCourses
- Ensured consistent rendering of course summary in both CourseDetailPage and CourseCard
- All changes verified across mobile and desktop layouts
- Filtered “Other Interesting Courses” section to show only courses with status = 'published'
- Ensures users only see publicly available courses and avoids draft or incomplete content