### PR TITLE
Admin/assignments list: feat: assignment list API with flat structure from nested joins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@radix-ui/react-select": "^2.2.4",
         "@radix-ui/react-separator": "^1.1.6",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tooltip": "^1.2.7",
         "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/supabase-js": "^2.49.4",
         "@types/swagger-ui-react": "^5.18.0",
@@ -2094,6 +2095,192 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.7.tgz",
+      "integrity": "sha512-Ap+fNYwKTYJ9pzqW+Xe2HtMRbQ/EeWkj2qykZ6SuEV4iS/o1bZI5ssJbk4D2r8XuDuOBVz/tIx2JObtuqU+5Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.7",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.10.tgz",
+      "integrity": "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.7.tgz",
+      "integrity": "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
@@ -2838,7 +3025,7 @@
       "version": "19.1.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
       "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-select": "^2.2.4",
     "@radix-ui/react-separator": "^1.1.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tooltip": "^1.2.7",
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "^2.49.4",
     "@types/swagger-ui-react": "^5.18.0",

--- a/src/app/admin/components/AssignmentsRow.tsx
+++ b/src/app/admin/components/AssignmentsRow.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import React from "react";
 import Image from "next/image";
-import { FullAssignment} from "@/types/Assignments";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { FullAssignment } from "@/types/Assignments";
 
 interface AssignmentRowProps {
   assignment: FullAssignment;
@@ -17,30 +20,53 @@ const AssignmentRow: React.FC<AssignmentRowProps> = ({
   onDelete,
   formatDate,
 }) => {
+  const renderTooltipCell = (
+    content: string | null | undefined,
+    maxWidth: string = "max-w-[240px]",
+    defaultText = "-"
+  ) => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <td
+          className={`px-6 py-4 whitespace-nowrap text-sm text-gray-700 truncate ${maxWidth} cursor-default`}
+        >
+          {content || defaultText}
+        </td>
+      </TooltipTrigger>
+      <TooltipContent>{content || defaultText}</TooltipContent>
+    </Tooltip>
+  );
+
   return (
     <tr key={assignment.id} className="hover:bg-gray-50 transition">
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">{index}</td>
 
-      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-        {assignment.description || "Untitled"}
-      </td>
+      {/* Description */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 max-w-[240px] truncate cursor-default">
+            {assignment.description || "Untitled"}
+          </td>
+        </TooltipTrigger>
+        <TooltipContent className="break-words max-w-[320px] whitespace-pre-wrap">
+          {assignment.description || "Untitled"}
+        </TooltipContent>
+      </Tooltip>
 
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
-        {assignment.course_name || "-"}
-      </td>
+      {/* Course Name */}
+      {renderTooltipCell(assignment.course_name, "max-w-[180px]")}
 
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
-        {assignment.lesson_name || "-"}
-      </td>
+      {/* Lesson Name */}
+      {renderTooltipCell(assignment.lesson_name, "max-w-[160px]")}
 
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
-        {assignment.sub_lesson_name || "-"}
-      </td>
+      {/* Sub-lesson Name */}
+      {renderTooltipCell(assignment.sub_lesson_name, "max-w-[200px]")}
 
+      {/* Created At */}
       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
         {formatDate(assignment.created_at)}
       </td>
 
+      {/* Action */}
       <td className="px-6 py-4 whitespace-nowrap text-center text-sm font-medium">
         <button
           onClick={() => onDelete(assignment.id)}

--- a/src/app/admin/components/AssignmentsRow.tsx
+++ b/src/app/admin/components/AssignmentsRow.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import Image from "next/image";
+import { FullAssignment} from "@/types/Assignments";
+
+interface AssignmentRowProps {
+  assignment: FullAssignment;
+  index: number;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+  formatDate: (dateString: string) => string;
+}
+
+const AssignmentRow: React.FC<AssignmentRowProps> = ({
+  assignment,
+  index,
+  onEdit,
+  onDelete,
+  formatDate,
+}) => {
+  return (
+    <tr key={assignment.id} className="hover:bg-gray-50 transition">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">{index}</td>
+
+      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+        {assignment.description || "Untitled"}
+      </td>
+
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
+        {assignment.course_name || "-"}
+      </td>
+
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
+        {assignment.lesson_name || "-"}
+      </td>
+
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
+        {assignment.sub_lesson_name || "-"}
+      </td>
+
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
+        {formatDate(assignment.created_at)}
+      </td>
+
+      <td className="px-6 py-4 whitespace-nowrap text-center text-sm font-medium">
+        <button
+          onClick={() => onDelete(assignment.id)}
+          className="text-blue-600 hover:text-blue-800 mr-3 transition"
+          aria-label="Delete assignment"
+        >
+          <Image src="/delete.svg" alt="Delete" width={18} height={18} />
+        </button>
+        <button
+          onClick={() => onEdit(assignment.id)}
+          className="text-blue-600 hover:text-blue-800 transition"
+          aria-label="Edit assignment"
+        >
+          <Image src="/edit.svg" alt="Edit" width={18} height={18} />
+        </button>
+      </td>
+    </tr>
+  );
+};
+
+export default AssignmentRow;

--- a/src/app/admin/components/AssignmentsTable.tsx
+++ b/src/app/admin/components/AssignmentsTable.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import AssignmentRow from "./AssignmentsRow";
+import { FullAssignment } from "@/types/Assignments";
+
+interface AssignmentsTableProps {
+  assignments: FullAssignment[];
+  onEditAssignment: (id: string) => void;
+  onDeleteAssignment: (id: string) => void;
+  formatDate: (dateString: string) => string;
+  isLoading: boolean;
+  currentPage: number;
+}
+
+const AssignmentsTable: React.FC<AssignmentsTableProps> = ({
+  assignments,
+  onEditAssignment,
+  onDeleteAssignment,
+  formatDate,
+  isLoading,
+  currentPage,
+}) => {
+  const tableHeaderClasses =
+    "px-6 py-3 text-left text-[14px] font-medium text-gray-500 uppercase tracking-wider";
+  const assignmentsPerPage = 10;
+
+  if (!isLoading && assignments.length === 0) {
+    return (
+      <div className="px-6 py-10 text-center text-gray-500 bg-white shadow-md rounded-lg">
+        No assignments found.
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white shadow-md rounded-lg overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-300">
+            <tr>
+              {["", "Detail", "Course", "Lesson", "Sub-lesson", "Created at", "Action"].map(
+                (header, idx) => (
+                  <th
+                    key={idx}
+                    className={`${tableHeaderClasses} ${
+                      header === "Action" ? "text-center" : ""
+                    }`}
+                  >
+                    {header}
+                  </th>
+                )
+              )}
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {assignments.map((assignment, index) => (
+              <AssignmentRow
+                key={assignment.id}
+                assignment={assignment}
+                index={(currentPage - 1) * assignmentsPerPage + index + 1}
+                onEdit={onEditAssignment}
+                onDelete={() => onDeleteAssignment(assignment.id)}
+                formatDate={formatDate}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default AssignmentsTable;

--- a/src/app/admin/components/AssignmentsTable.tsx
+++ b/src/app/admin/components/AssignmentsTable.tsx
@@ -37,7 +37,7 @@ const AssignmentsTable: React.FC<AssignmentsTableProps> = ({
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-300">
             <tr>
-              {["", "Detail", "Course", "Lesson", "Sub-lesson", "Created at", "Action"].map(
+              {["Detail", "Course", "Lesson", "Sub-lesson", "Created at", "Action"].map(
                 (header, idx) => (
                   <th
                     key={idx}

--- a/src/app/admin/components/Sidebar.tsx
+++ b/src/app/admin/components/Sidebar.tsx
@@ -32,7 +32,7 @@ export default function Sidebar() {
     {
       id: "assignment",
       name: "Assignment",
-      path: "/admin/assignments",
+      path: "/admin/dashboard/assignments",
       icon: MdOutlineAssignmentTurnedIn,
     },
     {

--- a/src/app/admin/context/AssignmentsContext.tsx
+++ b/src/app/admin/context/AssignmentsContext.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  ReactNode,
+} from "react";
+import { FullAssignment } from "@/types/Assignments";
+import ConfirmationModal from "../components/ConfirmationModal";
+import { useCustomToast } from "@/components/ui/CustomToast";
+
+interface PaginationData {
+  totalItems: number;
+  totalPages: number;
+  currentPage: number;
+  limit: number;
+}
+
+interface AssignmentsContextType {
+  assignments: FullAssignment[];
+  isLoading: boolean;
+  error: string | null;
+  searchTerm: string;
+  setSearchTerm: (term: string) => void;
+  handleDeleteAssignment: (id: string) => void;
+  fetchAssignments: () => Promise<void>;
+  currentPage: number;
+  totalPages: number;
+  assignmentsPerPage: number;
+  setCurrentPage: (page: number) => void;
+}
+
+const AssignmentsContext = createContext<AssignmentsContextType | undefined>(undefined);
+
+export const AssignmentsProvider = ({ children }: { children: ReactNode }) => {
+  const [assignments, setAssignments] = useState<FullAssignment[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [assignmentToDelete, setAssignmentToDelete] = useState<string | null>(null);
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pagination, setPagination] = useState<PaginationData>({
+    totalItems: 0,
+    totalPages: 0,
+    currentPage: 1,
+    limit: 10,
+  });
+  const assignmentsPerPage = 10;
+
+  const fetchAssignments = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const queryParams = new URLSearchParams({
+        page: currentPage.toString(),
+        limit: assignmentsPerPage.toString(),
+        search: searchTerm,
+      });
+
+      const response = await fetch(`/api/admin/assignments-list?${queryParams.toString()}`);
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || `Failed to fetch assignments`);
+      }
+
+      const data = await response.json();
+      setAssignments(data.assignments);
+      setPagination(data.pagination);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [currentPage, assignmentsPerPage, searchTerm]);
+
+  useEffect(() => {
+    fetchAssignments();
+  }, [fetchAssignments]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchTerm]);
+
+  const handleDeleteAssignment = useCallback((id: string) => {
+    setAssignmentToDelete(id);
+    setIsConfirmOpen(true);
+  }, []);
+
+  const { success, error: toastError } = useCustomToast();
+
+  const confirmDeleteAssignment = useCallback(async () => {
+    if (!assignmentToDelete) return;
+    try {
+      const response = await fetch(`/api/admin/assignments-delete/${assignmentToDelete}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || "Failed to delete assignment");
+      }
+
+      success("Assignment deleted successfully", "The assignment has been removed.");
+      fetchAssignments();
+    } catch (err) {
+      toastError("Failed to delete assignment", (err as Error).message);
+    } finally {
+      setIsConfirmOpen(false);
+      setAssignmentToDelete(null);
+    }
+  }, [assignmentToDelete, fetchAssignments]);
+
+  const contextValue = useMemo(
+    () => ({
+      assignments,
+      isLoading,
+      error,
+      searchTerm,
+      setSearchTerm,
+      handleDeleteAssignment,
+      fetchAssignments,
+      currentPage,
+      totalPages: pagination.totalPages,
+      assignmentsPerPage,
+      setCurrentPage,
+    }),
+    [assignments, isLoading, error, searchTerm, handleDeleteAssignment, fetchAssignments, currentPage, pagination.totalPages, assignmentsPerPage]
+  );
+
+  return (
+    <AssignmentsContext.Provider value={contextValue}>
+      {children}
+      <ConfirmationModal
+        isOpen={isConfirmOpen}
+        onClose={() => {
+          setIsConfirmOpen(false);
+          setAssignmentToDelete(null);
+        }}
+        onConfirm={confirmDeleteAssignment}
+        title="Delete Assignment"
+        message={<span className="text-red-600">Are you sure you want to delete this assignment?</span>}
+        confirmText="Yes, delete it"
+        cancelText="Cancel"
+      />
+    </AssignmentsContext.Provider>
+  );
+};
+
+export const useAssignmentsContext = () => {
+  const context = useContext(AssignmentsContext);
+  if (!context) {
+    throw new Error("useAssignmentsContext must be used within an AssignmentsProvider");
+  }
+  return context;
+};

--- a/src/app/admin/dashboard/assignments/page.tsx
+++ b/src/app/admin/dashboard/assignments/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import React, { useCallback } from "react";
+import { FiPlus } from "react-icons/fi";
+import { useRouter } from "next/navigation";
+import SearchBar from "../../components/SearchBar";
+import AssignmentsTable from "../../components/AssignmentsTable";
+import Pagination from "../../components/Pagination";
+import { useAssignmentsContext, AssignmentsProvider } from "../../context/AssignmentsContext";
+import LoadingSpinner from "../../components/LoadingSpinner";
+import { ButtonT } from "@/components/ui/ButtonT";
+
+export function AssignmentsPageContent() {
+  const router = useRouter();
+
+  const {
+    assignments,
+    isLoading,
+    error,
+    searchTerm,
+    setSearchTerm,
+    handleDeleteAssignment,
+    currentPage,
+    totalPages,
+    setCurrentPage,
+  } = useAssignmentsContext();
+
+  const handleAddAssignment = useCallback(() => {
+    router.push("/admin/create-assignments");
+  }, [router]);
+
+  const handleEditAssignment = useCallback((id: string) => {
+    router.push(`/admin/edit-assignments/${id}`);
+  }, [router]);
+
+  const formatDate = useCallback((dateString: string): string => {
+    if (!dateString) return "N/A";
+    try {
+      const date = new Date(dateString);
+      return `${date.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })} ${date.toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: true,
+      })}`;
+    } catch (e) {
+      console.error("Error formatting date:", dateString, e);
+      return dateString;
+    }
+  }, []);
+
+  return (
+    <div className="bg-gray-100 flex flex-col flex-1 min-h-screen">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row justify-between items-center gap-4 mb-8 bg-white px-4 sm:px-8 py-6 border-b-3 border-gray-200">
+        <h1 className="text-3xl font-semibold text-gray-800">Assignments</h1>
+        <div className="flex flex-col sm:flex-row items-center gap-4 w-full sm:w-auto">
+          <SearchBar
+            value={searchTerm}
+            onChange={setSearchTerm}
+            placeholder="Search assignments..."
+            className="w-full sm:w-64 md:w-72"
+          />
+          <ButtonT
+            onClick={handleAddAssignment}
+            className="w-full sm:w-auto px-4 py-2 flex justify-center items-center gap-3"
+          >
+            <FiPlus size={20} />
+            <span>Add Assignment</span>
+          </ButtonT>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 px-4 sm:px-8 pb-8 overflow-y-auto">
+        {isLoading && <LoadingSpinner text="Loading assignments..." size="md" />}
+        {error && (
+          <div className="text-center py-10 text-red-600 bg-red-100 p-4 rounded-md">
+            Error: {error}
+          </div>
+        )}
+
+        {!isLoading && !error && (
+          <>
+            {assignments.length > 0 ? (
+              <AssignmentsTable
+                assignments={assignments}
+                onEditAssignment={handleEditAssignment}
+                onDeleteAssignment={handleDeleteAssignment}
+                formatDate={formatDate}
+                isLoading={isLoading}
+                currentPage={currentPage}
+              />
+            ) : (
+              <div className="px-6 py-10 text-center text-gray-500 bg-white shadow-md rounded-lg">
+                No assignments found.
+              </div>
+            )}
+          </>
+        )}
+
+        {assignments.length > 0 && (
+          <div className="mt-4">
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={setCurrentPage}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function AssignmentsPage() {
+  return (
+    <AssignmentsProvider>
+      <AssignmentsPageContent />
+    </AssignmentsProvider>
+  );
+}

--- a/src/app/api/admin/assignments-list/route.ts
+++ b/src/app/api/admin/assignments-list/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabaseClient';
+import { FullAssignment } from '@/types/Assignments';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const page = parseInt(searchParams.get('page') || '1');
+  const limit = parseInt(searchParams.get('limit') || '10');
+  const search = searchParams.get('search') || '';
+
+  const offset = (page - 1) * limit;
+
+  try {
+    const { data, error, count } = await supabase
+      .from('assignments')
+      .select(`
+        id,
+        title,
+        description,
+        start_date,
+        end_date,
+        solution,
+        created_at,
+        updated_at,
+        sub_lessons (
+            id,
+            title,
+            lessons (
+                id,
+                title,
+                courses (
+                    id,
+                    name
+                )
+            )
+        )
+      `, { count: 'exact' })
+      .ilike('description', `%${search}%`)
+      .range(offset, offset + limit - 1);
+
+    console.log('Supabase data:', data);
+    console.log('Supabase error:', error);
+    console.log('Supabase count:', count);
+
+    if (error) {
+      console.error('Error fetching assignments:', error);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    // Helper function to safely extract nested name/title
+    function getFirst(arrOrObj: any): any {
+      if (Array.isArray(arrOrObj)) return arrOrObj.length > 0 ? arrOrObj[0] : undefined;
+      if (arrOrObj && typeof arrOrObj === 'object') return arrOrObj;
+      return undefined;
+    }
+
+    // Transform data into FullAssignment[]
+    const assignments: FullAssignment[] = (data || []).map((item) => {
+        const subLesson = getFirst(item.sub_lessons);
+        const lesson = getFirst(subLesson?.lessons);
+        const course = getFirst(lesson?.courses);
+
+        return {
+            id: item.id,
+            title: item.title,
+            description: item.description,
+            solution: item.solution,
+            start_date: item.start_date,
+            end_date: item.end_date,
+            created_at: item.created_at,
+            updated_at: item.updated_at,
+            course_id: course?.id ?? null,
+            lesson_id: lesson?.id ?? null,
+            sub_lesson_id: subLesson?.id ?? null,
+            course_name: course?.name ?? '',
+            lesson_name: lesson?.title ?? '',
+            sub_lesson_name: subLesson?.title ?? '',
+        };
+    });
+
+    const totalPages = Math.ceil((count || 0) / limit);
+
+    return NextResponse.json({
+      assignments,
+      pagination: {
+        totalItems: count,
+        totalPages,
+        currentPage: page,
+        limit,
+      },
+    });
+  } catch (error: any) {
+    console.error('Unexpected error:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/types/Assignments.ts
+++ b/src/types/Assignments.ts
@@ -1,0 +1,33 @@
+export interface Assignment {
+  id: string;
+  title: string;
+  description?: string;
+  course_id: string;
+  lesson_id: string;
+  sub_lesson_id: string;
+  start_date?: string;
+  end_date?: string;
+  solution?: string;
+  created_at: string;
+  updated_at?: string;
+}
+
+// ใช้ตอนดึงข้อมูลแบบ join จาก supabase
+export interface FullAssignment extends Assignment {
+  course_name: string;
+  lesson_name: string;
+  sub_lesson_name: string;
+}
+
+export type SubLessonDeepJoin = {
+  id: string;
+  title: string;
+  lessons: {
+    id: string;
+    title: string;
+    courses: {
+      id: string;
+      name: string;
+    };
+  };
+};


### PR DESCRIPTION
**What’s been done:**

- Created GET /api/admin/assignments-list endpoint to retrieve paginated assignment data from Supabase.
- Joined sub_lessons, lessons, and courses within the same query to reduce redundant DB calls.
- Transformed nested join data into a flat structure (course_name, lesson_name, sub_lesson_name) for easier consumption on the frontend.
- Implemented defensive programming using a helper getFirst() to handle optional or array-based nested relations safely.
- Fixed type mismatch errors and refactored the FullAssignment interface to match the transformed structure.

**Notes:**

- The endpoint supports pagination (page, limit) and search (description) via query parameters.
- Ensure that frontend expects the flattened assignment data and not nested sub_lesson object anymore.
- Type safety has been enforced by aligning response structure with the FullAssignment type.