### PR TITLE
Admin/create assignments: feat: create assignment form with validation, constraint, and tooltip enhancements

### DIFF
--- a/src/app/admin/components/AssignmentFormView.tsx
+++ b/src/app/admin/components/AssignmentFormView.tsx
@@ -181,13 +181,16 @@ export default function AssignmentFormView({
 
         <div>
           <Label className="text-[16px] mb-2">Assignment *</Label>
-          <Input
+          <textarea
             name="description"
             value={formData.description}
-            onChange={handleInputChange}
+            onChange={handleInputChange as any}
             placeholder="Enter assignment description"
             minLength={5}
             maxLength={300}
+            className={`w-full border p-2 rounded-md text-[16px] resize-y min-h-[100px] ${
+              errors.description ? "border-red-500" : ""
+            }`}
           />
           {errors.description && (
             <p className="text-red-500 text-sm mt-1">{errors.description}</p>
@@ -196,12 +199,15 @@ export default function AssignmentFormView({
 
         <div>
           <Label className="text-[16px] mb-2">Solution *</Label>
-          <Input
+          <textarea
             name="solution"
             value={formData.solution}
-            onChange={handleInputChange}
+            onChange={handleInputChange as any}
             placeholder="Enter solution"
             maxLength={500}
+            className={`w-full border p-2 rounded-md text-[16px] resize-y min-h-[100px] ${
+              errors.solution ? "border-red-500" : ""
+            }`}
           />
           {errors.solution && (
             <p className="text-red-500 text-sm mt-1">{errors.solution}</p>

--- a/src/app/admin/components/AssignmentFormView.tsx
+++ b/src/app/admin/components/AssignmentFormView.tsx
@@ -2,6 +2,12 @@ import React from "react";
 import { Input } from "@/components/ui/input";
 import { ButtonT } from "@/components/ui/ButtonT";
 import { Label } from "@/components/ui/label";
+import { 
+  Tooltip, 
+  TooltipContent, 
+  TooltipProvider, 
+  TooltipTrigger 
+} from "@/components/ui/tooltip";
 
 interface AssignmentFormViewProps {
   formData: {
@@ -16,6 +22,11 @@ interface AssignmentFormViewProps {
   subLessons: { id: string; title: string }[];
   errors: Record<string, string>;
   isLoading: boolean;
+  mode?: "create" | "edit";
+  heading?: string;
+  showBackButton?: boolean;
+  onBack?: () => void;
+  onDelete?: () => void;
   handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   handleSelect: (field: string, value: string) => void;
   handleCancel: () => void;
@@ -29,6 +40,11 @@ export default function AssignmentFormView({
   subLessons,
   errors,
   isLoading,
+  mode = "create",
+  heading,
+  showBackButton = false,
+  onBack,
+  onDelete,
   handleInputChange,
   handleSelect,
   handleCancel,
@@ -36,20 +52,52 @@ export default function AssignmentFormView({
 }: AssignmentFormViewProps) {
   return (
     <>
+      {/* Header */}
       <div className="flex justify-between items-center mb-8 bg-white px-8 py-6 border-b border-gray-200">
-        <h1 className="text-3xl font-semibold text-gray-800">
-          Add Assignment
-        </h1>
+        <div className="flex items-center gap-4">
+          {showBackButton && (
+            <button
+              onClick={onBack}
+              className="text-2xl text-[#9AA1B9] font-semibold hover:text-gray-900"
+            >
+              ← Assignment
+            </button>
+          )}
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <h1 className="text-2xl font-semibold text-black max-w-[500px] truncate cursor-help">
+                  {heading ?? 
+                    (mode === "edit" 
+                      ? formData.description || "Edit Assignment" 
+                      : "Add Assignment")}
+                </h1>
+              </TooltipTrigger>
+              {formData.description && (
+                <TooltipContent className="max-w-xs whitespace-pre-wrap break-words text-sm">
+                  <p>{formData.description}</p>
+                </TooltipContent>
+              )}
+            </Tooltip>
+          </TooltipProvider>
+        </div>
         <div className="flex items-center space-x-4">
           <ButtonT variant="Secondary" onClick={handleCancel}>
             Cancel
           </ButtonT>
           <ButtonT variant="primary" onClick={(e) => handleSubmit(e as any)}>
-            {isLoading ? "Creating..." : "Create"}
+            {isLoading
+              ? mode === "edit"
+                ? "Saving..."
+                : "Creating..."
+              : mode === "edit"
+              ? "Save"
+              : "Create"}
           </ButtonT>
         </div>
       </div>
 
+      {/* Form */}
       <form
         onSubmit={(e) => {
           e.preventDefault();
@@ -159,6 +207,19 @@ export default function AssignmentFormView({
             <p className="text-red-500 text-sm mt-1">{errors.solution}</p>
           )}
         </div>
+
+        {/* Delete button (only on edit mode) */}
+        {mode === "edit" && onDelete && (
+          <div className="flex justify-end mt-6">
+            <button
+              type="button"
+              className="text-[#2F5FAC] text-[16px] font-bold hover:text-blue-500"
+              onClick={onDelete}
+            >
+              Delete Assignment
+            </button>
+          </div>
+        )}
       </form>
     </>
   );

--- a/src/app/admin/components/AssignmentFormView.tsx
+++ b/src/app/admin/components/AssignmentFormView.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { Input } from "@/components/ui/input";
+import { ButtonT } from "@/components/ui/ButtonT";
+import { Label } from "@/components/ui/label";
+
+interface AssignmentFormViewProps {
+  formData: {
+    description: string;
+    solution: string;
+    courseId: string;
+    lessonId: string;
+    subLessonId: string;
+  };
+  courses: { id: string; name: string }[];
+  lessons: { id: string; title: string }[];
+  subLessons: { id: string; title: string }[];
+  errors: Record<string, string>;
+  isLoading: boolean;
+  handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleSelect: (field: string, value: string) => void;
+  handleCancel: () => void;
+  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+}
+
+export default function AssignmentFormView({
+  formData,
+  courses,
+  lessons,
+  subLessons,
+  errors,
+  isLoading,
+  handleInputChange,
+  handleSelect,
+  handleCancel,
+  handleSubmit,
+}: AssignmentFormViewProps) {
+  return (
+    <>
+      <div className="flex justify-between items-center mb-8 bg-white px-8 py-6 border-b border-gray-200">
+        <h1 className="text-3xl font-semibold text-gray-800">
+          Add Assignment
+        </h1>
+        <div className="flex items-center space-x-4">
+          <ButtonT variant="Secondary" onClick={handleCancel}>
+            Cancel
+          </ButtonT>
+          <ButtonT variant="primary" onClick={(e) => handleSubmit(e as any)}>
+            {isLoading ? "Creating..." : "Create"}
+          </ButtonT>
+        </div>
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit(e);
+        }}
+        className="bg-white mx-10 px-24 py-14 rounded-2xl space-y-6"
+      >
+        {/* Course */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <Label className="block font-medium text-[16px] mb-2">Course</Label>
+            <select
+              value={formData.courseId}
+              onChange={(e) => handleSelect("courseId", e.target.value)}
+              className="w-full border p-2 rounded-md text-[16px]"
+            >
+              <option value="">Place Holder</option>
+              {courses.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+            {errors.courseId && (
+              <p className="text-red-500 text-sm mt-1">{errors.courseId}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Lesson + Sub-lesson */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <Label className="text-[16px] mb-2">Lesson</Label>
+            <select
+              value={formData.lessonId}
+              onChange={(e) => handleSelect("lessonId", e.target.value)}
+              className="w-full border p-2 rounded-md text-[16px]"
+              disabled={!formData.courseId}
+            >
+              <option value="">Place Holder</option>
+              {lessons.map((l) => (
+                <option key={l.id} value={l.id}>
+                  {l.title}
+                </option>
+              ))}
+            </select>
+            {errors.lessonId && (
+              <p className="text-red-500 text-sm mt-1">{errors.lessonId}</p>
+            )}
+          </div>
+
+          <div>
+            <Label className="text-[16px] mb-2">Sub-lesson</Label>
+            <select
+              value={formData.subLessonId}
+              onChange={(e) => handleSelect("subLessonId", e.target.value)}
+              className="w-full border p-2 rounded-md text-[16px]"
+              disabled={!formData.lessonId}
+            >
+              <option value="">Place Holder</option>
+              {subLessons.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.title}
+                </option>
+              ))}
+            </select>
+            {errors.subLessonId && (
+              <p className="text-red-500 text-sm mt-1">
+                {errors.subLessonId}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <hr className="my-6 border-gray-300" />
+
+        {/* Assignment detail */}
+        <h2 className="text-[20px] font-semibold text-[#646D89]">
+          Assignment detail
+        </h2>
+
+        <div>
+          <Label className="text-[16px] mb-2">Assignment *</Label>
+          <Input
+            name="description"
+            value={formData.description}
+            onChange={handleInputChange}
+            placeholder="Enter assignment description"
+            minLength={5}
+            maxLength={300}
+          />
+          {errors.description && (
+            <p className="text-red-500 text-sm mt-1">{errors.description}</p>
+          )}
+        </div>
+
+        <div>
+          <Label className="text-[16px] mb-2">Solution *</Label>
+          <Input
+            name="solution"
+            value={formData.solution}
+            onChange={handleInputChange}
+            placeholder="Enter solution"
+            maxLength={500}
+          />
+          {errors.solution && (
+            <p className="text-red-500 text-sm mt-1">{errors.solution}</p>
+          )}
+        </div>
+      </form>
+    </>
+  );
+}

--- a/src/app/admin/context/AssignmentsContext.tsx
+++ b/src/app/admin/context/AssignmentsContext.tsx
@@ -144,9 +144,9 @@ export const AssignmentsProvider = ({ children }: { children: ReactNode }) => {
           setAssignmentToDelete(null);
         }}
         onConfirm={confirmDeleteAssignment}
-        title="Delete Assignment"
-        message={<span className="text-red-600">Are you sure you want to delete this assignment?</span>}
-        confirmText="Yes, delete it"
+        title="Confirmation"
+        message={<span className="">Are you sure you want to delete this assignment?</span>}
+        confirmText="Yes, delete"
         cancelText="Cancel"
       />
     </AssignmentsContext.Provider>

--- a/src/app/admin/dashboard/assignments/page.tsx
+++ b/src/app/admin/dashboard/assignments/page.tsx
@@ -26,11 +26,11 @@ export function AssignmentsPageContent() {
   } = useAssignmentsContext();
 
   const handleAddAssignment = useCallback(() => {
-    router.push("/admin/create-assignments");
+    router.push("/admin/dashboard/create-assignments");
   }, [router]);
 
   const handleEditAssignment = useCallback((id: string) => {
-    router.push(`/admin/edit-assignments/${id}`);
+    router.push(`/admin/dashboard/edit-assignments/${id}`);
   }, [router]);
 
   const formatDate = useCallback((dateString: string): string => {

--- a/src/app/admin/dashboard/create-assignments/page.tsx
+++ b/src/app/admin/dashboard/create-assignments/page.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import AssignmentFormView from "../../components/AssignmentFormView";
+import { useAssignmentForm } from "../../hooks/useAssignmentForm";
+
+export default function CreateAssignmentPage() {
+  const {
+    formData,
+    setFormData,
+    courses,
+    lessons,
+    subLessons,
+    errors,
+    isLoading,
+    handleInputChange,
+    handleSelect,
+    handleCancel,
+    handleSubmit,
+  } = useAssignmentForm();
+
+  return (
+    <div className="bg-gray-100 flex-1 pb-10">
+      <AssignmentFormView
+        formData={formData}
+        isLoading={isLoading}
+        courses={courses}
+        lessons={lessons}
+        subLessons={subLessons}
+        errors={errors}
+        handleInputChange={handleInputChange}
+        handleSelect={handleSelect}
+        handleCancel={handleCancel}
+        handleSubmit={handleSubmit}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/dashboard/edit-assignments/[id]/page.tsx
+++ b/src/app/admin/dashboard/edit-assignments/[id]/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabaseClient";
+import AssignmentFormView from "@/app/admin/components/AssignmentFormView";
+import { useAssignmentForm } from "@/app/admin/hooks/useAssignmentForm";
+import ConfirmationModal from "@/app/admin/components/ConfirmationModal";
+
+export default function EditAssignmentPage() {
+  const params = useParams();
+  const assignmentId = params.id as string;
+  const router = useRouter();
+
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const {
+    formData,
+    setFormData,
+    courses,
+    lessons,
+    subLessons,
+    errors,
+    isLoading,
+    handleInputChange,
+    handleSelect,
+    handleCancel,
+    handleUpdate,
+    handleDeleteAssignment,
+  } = useAssignmentForm("edit", assignmentId);
+
+  useEffect(() => {
+    const fetchAssignment = async () => {
+      const { data, error } = await supabase
+        .from("assignments")
+        .select("description, solution, course_id, lesson_id, sub_lesson_id")
+        .eq("id", assignmentId)
+        .single();
+
+      if (error || !data) return;
+
+      setFormData({
+        description: data.description,
+        solution: data.solution,
+        courseId: data.course_id,
+        lessonId: data.lesson_id,
+        subLessonId: data.sub_lesson_id,
+      });
+    };
+
+    if (assignmentId) fetchAssignment();
+  }, [assignmentId, setFormData]);
+
+  return (
+    <>
+      <AssignmentFormView
+        mode="edit"
+        formData={formData}
+        courses={courses}
+        lessons={lessons}
+        subLessons={subLessons}
+        errors={errors}
+        isLoading={isLoading}
+        handleInputChange={handleInputChange}
+        handleSelect={handleSelect}
+        handleCancel={handleCancel}
+        handleSubmit={handleUpdate}
+        showBackButton={true}
+        onBack={() => router.push("/admin/dashboard/assignments")}
+        onDelete={() => setShowDeleteModal(true)}
+      />
+
+      {showDeleteModal && (
+        <ConfirmationModal
+          isOpen={showDeleteModal}
+          title="Confirmation"
+          message="Are you sure you want to delete this assignment?"
+          confirmText="Yes, delete"
+          cancelText="Cancel"
+          onConfirm={handleDeleteAssignment}
+          onClose={() => setShowDeleteModal(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/hooks/useAssignmentForm.ts
+++ b/src/app/admin/hooks/useAssignmentForm.ts
@@ -64,6 +64,29 @@ export function useAssignmentForm(mode: "create" | "edit" = "create", assignment
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
+
+    // Auto show warning if reaching maxLength
+    if (name === "description" && value.length >= 300) {
+      setErrors((prev) => ({
+        ...prev,
+        description: "You've reached the 300 character limit.",
+      }));
+    } else if (name === "solution" && value.length >= 500) {
+      setErrors((prev) => ({
+        ...prev,
+        solution: "You've reached the 500 character limit.",
+      }));
+    } else {
+    // Clear limit-related errors
+      setErrors((prev) => ({
+        ...prev,
+        [name]: prev[name] === "You've reached the 300 character limit." ||
+                prev[name] === "You've reached the 500 character limit."
+          ? ""
+          : prev[name],
+      }));
+    }
+    
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 

--- a/src/app/admin/hooks/useAssignmentForm.ts
+++ b/src/app/admin/hooks/useAssignmentForm.ts
@@ -1,0 +1,172 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useCustomToast } from "@/components/ui/CustomToast";
+import { supabase } from "@/lib/supabaseClient";
+import { getBangkokISOString } from "@/lib/bangkokTime";
+
+interface AssignmentFormData {
+  description: string;
+  solution: string;
+  courseId: string;
+  lessonId: string;
+  subLessonId: string;
+}
+
+export function useAssignmentForm() {
+  const router = useRouter();
+  const { success: toastSuccess, error: toastError } = useCustomToast();
+
+  const [formData, setFormData] = useState<AssignmentFormData>({
+    description: "",
+    solution: "",
+    courseId: "",
+    lessonId: "",
+    subLessonId: "",
+  });
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [courses, setCourses] = useState<any[]>([]);
+  const [lessons, setLessons] = useState<any[]>([]);
+  const [subLessons, setSubLessons] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchCourses = async () => {
+      const { data } = await supabase.from("courses").select("id, name");
+      if (data) setCourses(data);
+    };
+    fetchCourses();
+  }, []);
+
+  useEffect(() => {
+    if (!formData.courseId) return;
+    const fetchLessons = async () => {
+      const { data } = await supabase
+        .from("lessons")
+        .select("id, title")
+        .eq("course_id", formData.courseId);
+      if (data) setLessons(data);
+    };
+    fetchLessons();
+  }, [formData.courseId]);
+
+  useEffect(() => {
+    if (!formData.lessonId) return;
+    const fetchSubLessons = async () => {
+      const { data } = await supabase
+        .from("sub_lessons")
+        .select("id, title")
+        .eq("lesson_id", formData.lessonId);
+      if (data) setSubLessons(data);
+    };
+    fetchSubLessons();
+  }, [formData.lessonId]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSelect = (field: keyof AssignmentFormData, value: string) => {
+    if (field === "courseId") {
+      setFormData((prev) => ({
+        ...prev,
+        courseId: value,
+        lessonId: "",
+        subLessonId: "",
+      }));
+    } else if (field === "lessonId") {
+      setFormData((prev) => ({
+        ...prev,
+        lessonId: value,
+        subLessonId: "",
+      }));
+    } else {
+      setFormData((prev) => ({ ...prev, [field]: value }));
+    }
+  };
+
+  const handleCancel = () => {
+    router.push("/admin/dashboard/assignments");
+  };
+
+  const handleSubmit = async () => {
+    const newErrors: Record<string, string> = {};
+
+    if (!formData.courseId) newErrors.courseId = "Please select course";
+    if (!formData.lessonId) newErrors.lessonId = "Please select lesson";
+    if (!formData.subLessonId) newErrors.subLessonId = "Please select sub-lesson";
+
+    if (formData.description.trim().length < 5) {
+    newErrors.description = "Assignment must be at least 5 characters";
+    }
+    if (!formData.description.trim()) {
+      newErrors.description = "Please enter assignment";
+    } else if (formData.description.length > 300) {
+      newErrors.description = "Assignment is too long (max 300 characters)";
+    }
+
+    if (!formData.solution.trim()) {
+      newErrors.solution = "Please enter solution";
+    } else if (formData.solution.length > 500) {
+      newErrors.solution = "Solution is too long (max 500 characters)";
+    }
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      toastError("Please fill all required fields");
+      return;
+    }
+
+    setErrors({});
+    setIsLoading(true);
+
+    try {
+      const { data: existing } = await supabase
+        .from("assignments")
+        .select("id")
+        .eq("sub_lesson_id", formData.subLessonId);
+
+      if (existing && existing.length > 0) {
+        toastError("This sub-lesson already has an assignment.");
+        setIsLoading(false);
+        return;
+      }
+
+      const now = getBangkokISOString();
+
+      const { error } = await supabase.from("assignments").insert({
+        description: formData.description.trim(),
+        solution: formData.solution.trim(),
+        course_id: formData.courseId,
+        lesson_id: formData.lessonId,
+        sub_lesson_id: formData.subLessonId,
+        created_at: now,
+        updated_at: now,
+      });
+
+      if (error) throw error;
+
+      toastSuccess("Assignment created successfully!");
+      router.push("/admin/dashboard/assignments");
+    } catch (err: any) {
+      toastError("Failed to create assignment.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    formData,
+    setFormData,
+    courses,
+    lessons,
+    subLessons,
+    errors,
+    isLoading,
+    handleInputChange,
+    handleSelect,
+    handleCancel,
+    handleSubmit,
+  };
+}

--- a/src/app/api/admin/assignments-delete/[id]/route.ts
+++ b/src/app/api/admin/assignments-delete/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { supabase } from "@/lib/supabaseClient";
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const assignmentId = params.id;
+
+  const { error } = await supabase
+    .from("assignments")
+    .delete()
+    .eq("id", assignmentId);
+
+  if (error) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}


### PR DESCRIPTION
**Assignment Creation Page**

- Developed Create Assignment page according to 
- > Figma design:
- > Top-right buttons (Cancel, Create)
- Full form layout in card-like section
- Cascading dropdowns: Course → Lesson → Sub-lesson
- Input fields: Description, Solution
- Real-time form validation:
- > Description: min 5 characters
- > Solution: required
- Display inline error messages for invalid inputs
- Show toast notifications on success or error
- On success, redirect to /admin/dashboard/assignments

**UI/UX Enhancements**
- Consistent paddings, borders, text sizes (16px), spacing between labels and inputs
- Added gray divider line between dropdowns and "Assignment Detail" section
- Custom label styling (Assignment detail in 20px, bold, #646D89)
- Ensured dropdown font size = 16px
- Tooltip for long description text in the table (max 300 chars shown)
- > Word wrapping enabled for long, unbroken strings
- > Tooltip content auto-wraps and is width-limited
- Removed index (number) column for a cleaner UI

**Form Logic**
- Disabled Create button only if required fields are missing
- Allow short solutions like "a", "b", "1", etc.
- Enforced 1 assignment per sub-lesson constraint
- Real-time created_at and updated_at timestamps (Asia/Bangkok timezone)

**Technicals**
- Used shadcn/ui components for Tooltip, Button, etc.
- Form logic modularized using AssignmentFormView + useAssignmentForm() (similar to promo code structure)

**Styling**
- Added tooltip to the assignment description column to show full text on hover
- Tooltip handles long text by wrapping words and limiting max width
- Removed the index (numbering) column from the assignment table
- Changes applied via ConfirmationModal in AssignmentsContext