### PR TITLE
User/assignments-list: Add support for force deleting assignments with existing submissions

### DIFF
--- a/src/app/admin/components/AssignmentFormView.tsx
+++ b/src/app/admin/components/AssignmentFormView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Input } from "@/components/ui/input";
 import { ButtonT } from "@/components/ui/ButtonT";
 import { Label } from "@/components/ui/label";
+import { IoIosArrowBack } from "react-icons/io";
 import { 
   Tooltip, 
   TooltipContent, 
@@ -58,15 +58,16 @@ export default function AssignmentFormView({
           {showBackButton && (
             <button
               onClick={onBack}
-              className="text-2xl text-[#9AA1B9] font-semibold hover:text-gray-900"
+              className="flex items-center gap-2 text-3xl text-[#9AA1B9] font-semibold hover:text-gray-900 cursor-pointer"
             >
-              ← Assignment
+              <IoIosArrowBack className="h-7 w-7 text-gray-600" />
+              <span>Assignment</span>
             </button>
           )}
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <h1 className="text-2xl font-semibold text-black max-w-[500px] truncate cursor-help">
+                <h1 className="text-3xl font-semibold text-black max-w-[500px] truncate">
                   {heading ?? 
                     (mode === "edit" 
                       ? formData.description || "Edit Assignment" 

--- a/src/app/admin/components/AssignmentsRow.tsx
+++ b/src/app/admin/components/AssignmentsRow.tsx
@@ -2,7 +2,6 @@
 
 import React from "react";
 import Image from "next/image";
-import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import TooltipCell from "./TooltipCell";
 import { FullAssignment } from "@/types/Assignments";
 

--- a/src/app/admin/components/ConfirmationModal.tsx
+++ b/src/app/admin/components/ConfirmationModal.tsx
@@ -8,12 +8,13 @@ interface ConfirmationModalProps {
   onConfirm: () => void;
   title?: string;
   message: ReactNode;
-  confirmText?: string;
-  cancelText?: string;
+  confirmText?: ReactNode;
+  cancelText?: ReactNode;
   confirmButtonClass?: string;
   cancelButtonClass?: string;
   requireCourseName?: boolean;
   courseName?: string;
+  customModalSize?: string;
 }
 
 export default function ConfirmationModal({
@@ -28,6 +29,7 @@ export default function ConfirmationModal({
   cancelButtonClass = "bg-blue-600 text-white hover:bg-blue-700",
   requireCourseName = false,
   courseName = "",
+  customModalSize,
 }: ConfirmationModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -67,7 +69,9 @@ export default function ConfirmationModal({
     <div className="fixed inset-0 bg-black/90 flex items-center justify-center z-50 p-4">
       <div 
         ref={modalRef}
-        className="bg-white rounded-lg shadow-xl max-w-md w-full overflow-hidden"
+        className={`bg-white rounded-lg shadow-xl overflow-hidden ${ 
+         customModalSize ?? "max-w-md w-full"
+        }`}
       >
         <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
           <h3 className="text-xl font-medium text-gray-900">{title}</h3>

--- a/src/app/admin/context/AssignmentsContext.tsx
+++ b/src/app/admin/context/AssignmentsContext.tsx
@@ -88,32 +88,68 @@ export const AssignmentsProvider = ({ children }: { children: ReactNode }) => {
     setCurrentPage(1);
   }, [searchTerm]);
 
+  const [isSecondConfirmOpen, setIsSecondConfirmOpen] = useState(false);
+
+  const { success, error: toastError } = useCustomToast();
+
   const handleDeleteAssignment = useCallback((id: string) => {
     setAssignmentToDelete(id);
     setIsConfirmOpen(true);
   }, []);
 
-  const { success, error: toastError } = useCustomToast();
-
-  const confirmDeleteAssignment = useCallback(async () => {
+  // Force Delete Assignment with Submission
+  const deleteAssignmentById = useCallback(async () => {
     if (!assignmentToDelete) return;
+
     try {
-      const response = await fetch(`/api/admin/assignments-delete/${assignmentToDelete}`, {
+      const res = await fetch(`/api/admin/assignments-delete/${assignmentToDelete}/force`, {
         method: "DELETE",
       });
 
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || "Failed to delete assignment");
+      if (!res.ok) {
+        const errData = await res.json();
+        throw new Error(errData.error || "Failed to delete assignment");
       }
 
-      success("Assignment deleted successfully", "The assignment has been removed.");
+      success("Assignment deleted successfully", "The assignment and its submissions were removed.");
       fetchAssignments();
     } catch (err) {
       toastError("Failed to delete assignment", (err as Error).message);
     } finally {
-      setIsConfirmOpen(false);
+      setIsSecondConfirmOpen(false);
       setAssignmentToDelete(null);
+    }
+  }, [assignmentToDelete, fetchAssignments]);
+
+  // Delete Assignment with No submission
+  const confirmDeleteAssignment = useCallback(async () => {
+    if (!assignmentToDelete) return;
+
+    try {
+      const res = await fetch(`/api/admin/assignment-has-submission?id=${assignmentToDelete}`);
+      const result = await res.json();
+
+      //modal check submission assignment
+      if (result.hasSubmission) {
+        setIsSecondConfirmOpen(true);
+      } else {
+        const response = await fetch(`/api/admin/assignments-delete/${assignmentToDelete}`, {
+          method: "DELETE",
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.error || "Failed to delete assignment");
+        }
+
+        success("Assignment deleted successfully", "The assignment has been removed.");
+        fetchAssignments();
+        setAssignmentToDelete(null);
+      }
+    } catch (err) {
+      toastError("Failed to delete assignment", (err as Error).message);
+    } finally {
+      setIsConfirmOpen(false);
     }
   }, [assignmentToDelete, fetchAssignments]);
 
@@ -146,7 +182,33 @@ export const AssignmentsProvider = ({ children }: { children: ReactNode }) => {
         onConfirm={confirmDeleteAssignment}
         title="Confirmation"
         message={<span className="">Are you sure you want to delete this assignment?</span>}
-        confirmText="Yes, delete"
+        confirmText={
+          <span className="whitespace-nowrap">
+            Yes, want to delete the assignment
+          </span>
+        }
+        cancelText={
+          <span className="whitespace-nowrap">
+            No, keep it
+          </span>
+        }
+        customModalSize="w-fit wax-w-full"
+      />
+
+      <ConfirmationModal
+        isOpen={isSecondConfirmOpen}
+        onClose={() => {
+          setIsSecondConfirmOpen(false);
+          setAssignmentToDelete(null);
+        }}
+        onConfirm={deleteAssignmentById}
+        title="This assignment has submissions"
+        message={
+          <span className="text-red-600">
+            Are you sure you want to permanently delete this assignment and all related submissions?
+          </span>
+        }
+        confirmText="Yes, delete anyway"
         cancelText="Cancel"
       />
     </AssignmentsContext.Provider>

--- a/src/app/admin/dashboard/edit-assignments/[id]/page.tsx
+++ b/src/app/admin/dashboard/edit-assignments/[id]/page.tsx
@@ -52,6 +52,26 @@ export default function EditAssignmentPage() {
     if (assignmentId) fetchAssignment();
   }, [assignmentId, setFormData]);
 
+  const [showConfirmForceDeleteModal, setShowConfirmForceDeleteModal] = useState(false);
+
+  const checkSubmissionAndHandleDelete = async () => {
+    try {
+      const res = await fetch(`/api/admin/assignment-has-submission?id=${assignmentId}`);
+      const result = await res.json();
+
+      // checking submission assignment
+      if (result.hasSubmission) {
+        setShowDeleteModal(false);
+        setShowConfirmForceDeleteModal(true);
+      } else {
+        await handleDeleteAssignment();
+        router.push("/admin/dashboard/assignments");
+      }
+    } catch (error) {
+      console.error("Failed to check submission:", error);
+    }
+  };
+
   return (
     <>
       <AssignmentFormView
@@ -76,10 +96,36 @@ export default function EditAssignmentPage() {
           isOpen={showDeleteModal}
           title="Confirmation"
           message="Are you sure you want to delete this assignment?"
-          confirmText="Yes, delete"
-          cancelText="Cancel"
-          onConfirm={handleDeleteAssignment}
+          confirmText={
+            <span className="whitespace-nowrap">
+              Yes, want to delete the assignment
+            </span>
+          }
+          cancelText={
+          <span className="whitespace-nowrap">
+            No, keep it
+            </span>
+          }
+          onConfirm={checkSubmissionAndHandleDelete}
           onClose={() => setShowDeleteModal(false)}
+          customModalSize="w-fit wax-w-full"
+        />
+      )}
+
+      {showConfirmForceDeleteModal && (
+        <ConfirmationModal
+          isOpen={showConfirmForceDeleteModal}
+          title="This assignment has submissions"
+          message={
+            <span className="text-red-600">
+              Are you sure you want to permanently delete this assignment and all related submissions?
+            </span>}
+          confirmText="Yes, delete anyway"
+          cancelText="Cancel"
+          onConfirm={async () => {
+            await handleDeleteAssignment(true);
+          }}
+          onClose={() => setShowConfirmForceDeleteModal(false)}
         />
       )}
     </>

--- a/src/app/api/admin/assignment-has-submission/route.ts
+++ b/src/app/api/admin/assignment-has-submission/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabaseClient";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+
+  if (!id) {
+    return NextResponse.json({ error: "Missing id" }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from("submissions")
+    .select("id")
+    .eq("assignment_id", id)
+    .limit(1);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ hasSubmission: data.length > 0 });
+}

--- a/src/app/api/admin/assignments-delete/[id]/force/route.ts
+++ b/src/app/api/admin/assignments-delete/[id]/force/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { supabase } from "@/lib/supabaseClient";
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const assignmentId = params.id;
+
+  if (!assignmentId) {
+    return NextResponse.json({ error: "Assignment ID is required" }, { status: 400 });
+  }
+
+  try {
+    // 1. Delete submissions first
+    const { error: submissionDeleteError } = await supabase
+      .from("submissions")
+      .delete()
+      .eq("assignment_id", assignmentId);
+
+    if (submissionDeleteError) {
+      return NextResponse.json(
+        {
+          error: "Failed to delete related submissions",
+          details: submissionDeleteError.message,
+        },
+        { status: 500 }
+      );
+    }
+
+    // 2. Then delete the assignment
+    const { error: assignmentDeleteError } = await supabase
+      .from("assignments")
+      .delete()
+      .eq("id", assignmentId);
+
+    if (assignmentDeleteError) {
+      return NextResponse.json(
+        {
+          error: "Failed to delete assignment",
+          details: assignmentDeleteError.message,
+        },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      message: "Assignment and submissions deleted successfully.",
+    });
+  } catch (error: any) {
+    console.error("Unexpected error in /force delete:", error);
+    return NextResponse.json(
+      {
+        error: "Unexpected error occurred",
+        details: error.message || "Unknown",
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
### Summary

This PR introduces a safer and clearer way to handle assignment deletions in the admin dashboard.

### What's Changed
- Added `checkSubmissionAndHandleDelete` to verify if assignment has submissions before deletion.
- Added force delete confirmation modal when submissions exist.
- Updated `ConfirmationModal` to:
  - Accept `ReactNode` for `confirmText` and `cancelText`.
  - Optionally expand modal width dynamically using `customModalSize` prop.
- Adjusted UI to align back button icon with text in the header.
- Updated toast messages to distinguish between normal delete and force delete.

### Tested
- No submissions → standard delete confirmation
- With submissions → force delete confirmation modal shown
- Cancel from modal → nothing deleted
- Confirm force delete → assignment and submissions deleted
- Modal layout and styles work independently of other usages

### Next Steps
- Optionally refactor modal props and reusable confirmation logic
- Add unit/integration tests for delete logic

---

Let me know if any changes are needed!
