### PR TITLE
fix: update promocode can null

### DIFF
--- a/src/app/(main)/payment/[courseId]/page.tsx
+++ b/src/app/(main)/payment/[courseId]/page.tsx
@@ -122,7 +122,7 @@ export default function PaymentPage() {
           courseName: course?.name,
           userName: user?.full_name,
           paymentMethod: paymentMethodLabel,
-          promoCode: promoResult.promoCodeId || null,
+          promoCode: promoResult?.promoCodeId || null,
         });
         router.push(`/payment/${courseId}/order-completed`);
         return;


### PR DESCRIPTION
This pull request includes a small change to the `PaymentPage` component in `page.tsx`. The change ensures that `promoResult` is safely accessed using optional chaining when retrieving the `promoCodeId`. ([src/app/(main)/payment/[courseId]/page.tsxL125-R125](diffhunk://#diff-3947621ee15bd33d0f00a3bf6ff10542bb82a36cc1fd25814544b161a4e0126cL125-R125))