### PR TITLE
Change assignment list to sort and display by updated_at instead of created_at

### DIFF
--- a/src/app/admin/components/AssignmentsRow.tsx
+++ b/src/app/admin/components/AssignmentsRow.tsx
@@ -15,7 +15,6 @@ interface AssignmentRowProps {
 
 const AssignmentRow: React.FC<AssignmentRowProps> = ({
   assignment,
-  index,
   onEdit,
   onDelete,
   formatDate,
@@ -42,7 +41,7 @@ const AssignmentRow: React.FC<AssignmentRowProps> = ({
 
       {/* Created At */}
       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
-        {formatDate(assignment.created_at)}
+        {formatDate(assignment.updated_at)}
       </td>
 
       {/* Action */}

--- a/src/app/admin/components/AssignmentsTable.tsx
+++ b/src/app/admin/components/AssignmentsTable.tsx
@@ -37,7 +37,7 @@ const AssignmentsTable: React.FC<AssignmentsTableProps> = ({
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-300">
             <tr>
-              {["Detail", "Course", "Lesson", "Sub-lesson", "Created at", "Action"].map(
+              {["Detail", "Course", "Lesson", "Sub-lesson", "Updated at", "Action"].map(
                 (header, idx) => (
                   <th
                     key={idx}

--- a/src/app/api/admin/assignments-list/route.ts
+++ b/src/app/api/admin/assignments-list/route.ts
@@ -36,7 +36,7 @@ export async function GET(req: NextRequest) {
         )
       `, { count: 'exact' })
       .ilike('description', `%${search}%`)
-      .order('created_at', { ascending: false })
+      .order('updated_at', { ascending: false })
       .range(offset, offset + limit - 1);
 
     if (error) {


### PR DESCRIPTION
### Changes:
- Updated API `/api/admin/assignments-list` to order assignments by `updated_at` instead of `created_at`
- Displayed timestamp now reflects `updated_at` for better clarity on recent changes
- Restored full column selection to avoid type mismatches with `FullAssignment`

### Reason:
This helps the admin team quickly identify recently modified assignments, which improves content management and workflow visibility.
